### PR TITLE
Update azure-pipelines.yaml

### DIFF
--- a/.azure-pipelines/azure-pipelines.yaml
+++ b/.azure-pipelines/azure-pipelines.yaml
@@ -116,23 +116,3 @@ stages:
   - template: jobs/publish-channel.yaml
     parameters:
       channel: preview
-
-  - job: update_github_release
-    displayName: Update GitHub release
-    pool:
-      vmImage: 'ubuntu-20.04'
-    steps:
-
-    # Update GitHub release
-    - task: GitHubRelease@0
-      displayName: 'GitHub release'
-      inputs:
-        gitHubConnection: 'AzureDevOps-PSDocs-vscode'
-        repositoryName: '$(Build.Repository.Name)'
-        action: edit
-        tag: '$(Build.SourceBranchName)'
-        releaseNotesSource: input
-        releaseNotes: 'See [change log](https://github.com/Microsoft/PSDocs-vscode/blob/main/CHANGELOG.md)'
-        assetUploadMode: replace
-        addChangeLog: false
-        isPreRelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This extension is available in two release channels for Visual Studio Code from 
 Continue reading to see the changes included in the latest version.
 
 ## Unreleased
-
+Updated Pipeline step to remove GitHub release.
 
 ## v0.3.2
 17 Jan 2024 Engineering updates


### PR DESCRIPTION
Removed GitHub Release steps

## PR Summary

Updated Azure Pipeline and removed GitHub release step due to incorrect tagging.

## PR Checklist

- [X] PR has a meaningful title
- [X] Summarized changes
- [X] Change is not breaking
- [X] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [X] Link to a filed issue
  - [X] [Change log](https://github.com/Microsoft/PSDocs-vscode/blob/main/CHANGELOG.md) has been updated with change under unreleased section